### PR TITLE
Allow any renderable type in notification title and message. 

### DIFF
--- a/src/Notification.js
+++ b/src/Notification.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 class Notification extends React.Component {
   static propTypes = {
     type: React.PropTypes.oneOf(['info', 'success', 'warning', 'error']),
-    title: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-    message: React.PropTypes.string.isRequired,
+    title: React.PropTypes.node,
+    message: React.PropTypes.node.isRequired,
     timeOut: React.PropTypes.number,
     onClick: React.PropTypes.func,
     onRequestHide: React.PropTypes.func


### PR DESCRIPTION
Allow any renderable element in the notification message or title. This could, for example, make it possible to add a button to a notification.

https://facebook.github.io/react/docs/reusable-components.html#prop-validation
