### PR TITLE
Changed React.PropTypes to prop-types package

### DIFF
--- a/example/app/components/App.js
+++ b/example/app/components/App.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Header from './Header';
 import Footer from './Footer';
 
 class App extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {

--- a/example/app/components/common/Document.js
+++ b/example/app/components/common/Document.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Document extends React.Component {
   static propTypes = {
-    title: React.PropTypes.string,
-    className: React.PropTypes.string,
-    children: React.PropTypes.any.isRequired
+    title: PropTypes.string,
+    className: PropTypes.string,
+    children: PropTypes.any.isRequired
   };
 
   state = {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node-sass": "^3.4.2",
     "opn": "^4.0.0",
     "postcss-loader": "^0.8.0",
+    "prop-types": "^15.5.8",
     "react-dom": "^0.14 || ^15.0.0",
     "react-router": "^2.0.0",
     "react-transform-hmr": "^1.0.1",

--- a/src/Notification.js
+++ b/src/Notification.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 class Notification extends React.Component {
   static propTypes = {
-    type: React.PropTypes.oneOf(['info', 'success', 'warning', 'error']),
-    title: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-    message: React.PropTypes.string.isRequired,
-    timeOut: React.PropTypes.number,
-    onClick: React.PropTypes.func,
-    onRequestHide: React.PropTypes.func
+    type: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    message: PropTypes.string.isRequired,
+    timeOut: PropTypes.number,
+    onClick: PropTypes.func,
+    onRequestHide: PropTypes.func
   };
 
   static defaultProps = {
@@ -62,5 +63,3 @@ class Notification extends React.Component {
 }
 
 export default Notification;
-
-

--- a/src/NotificationContainer.js
+++ b/src/NotificationContainer.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import NotificationManager from './NotificationManager';
 import Notifications from './Notifications';
 
 class NotificationContainer extends React.Component {
   static propTypes = {
-    enterTimeout: React.PropTypes.number,
-    leaveTimeout: React.PropTypes.number
+    enterTimeout: PropTypes.number,
+    leaveTimeout: PropTypes.number
   };
 
   static defaultProps = {

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Notification from './Notification';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classnames from 'classnames';
 
 class Notifications extends React.Component {
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
-    onRequestHide: React.PropTypes.func,
-    enterTimeout: React.PropTypes.number,
-    leaveTimeout: React.PropTypes.number
+    notifications: PropTypes.array.isRequired,
+    onRequestHide: PropTypes.func,
+    enterTimeout: PropTypes.number,
+    leaveTimeout: PropTypes.number
   };
 
   static defaultProps = {
@@ -55,4 +56,3 @@ class Notifications extends React.Component {
 }
 
 export default Notifications;
-


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5. 
More info https://facebook.github.io/react/docs/typechecking-with-proptypes.html